### PR TITLE
Fix CSS being "linked" with script tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-ngdocs",
-  "version": "0.2.7-custom2",
+  "version": "0.2.8-custom2",
   "description": "grunt plugin for angularjs documentation",
   "main": "tasks",
   "repository": {

--- a/src/templates/js/docs.js
+++ b/src/templates/js/docs.js
@@ -29,10 +29,16 @@ docsApp.directive.ngHtmlWrapLoaded = function(reindentCode, templateMerge, loade
             module: '',
             body: element.text()
           },
-        html = "<!doctype html>\n<html ng-app{{module}}>\n  <head>\n{{head:4}}  </head>\n  <body>\n{{body:4}}  </body>\n</html>";
+        html = "<!doctype html>\n<html ng-app{{module}}>\n  <head>\n{{head:4}}  </head>\n  <body>\n{{body:4}}  </body>\n</html>",
+        cssFilePathRegex = /\.css$/; // any string that ends in '.css'
 
       angular.forEach(loadedUrls.base, function(dep) {
-        properties.head += '<script src="' + dep + '"></script>\n';
+        // if the file is css, make sure we link it that way!
+        if (cssFilePathRegex.test(dep)) {
+          properties.head += '<link rel="stylesheet" href="' + dep + '" type="text/css">\n';
+        } else {
+          properties.head += '<script src="' + dep + '"></script>\n';
+        }
       });
 
       angular.forEach((attr.ngHtmlWrapLoaded || '').split(' '), function(dep) {


### PR DESCRIPTION
- Fix an issue where all files, no matter whether they are .css, .js, or .foo, are displayed in the editor as being loaded with a 'script' tag even though in the background, they are loaded correctly (.css files use the 'link' tag)
- Bump version
